### PR TITLE
Extra configuration and fix

### DIFF
--- a/PseudoLocalize/Program.cs
+++ b/PseudoLocalize/Program.cs
@@ -2,7 +2,9 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.IO;
+    using System.Linq;
     using System.Security;
     using PseudoLocalizer.Core;
 
@@ -259,9 +261,7 @@
                 }
                 else
                 {
-                    var outputFileName = Path.Combine(
-                        Path.GetDirectoryName(inputFileName),
-                        Path.GetFileNameWithoutExtension(inputFileName) + "." + OutputCulture + Path.GetExtension(inputFileName));
+                    string outputFileName = GetOutputFileName(inputFileName);
 
                     using (var inputStream = File.OpenRead(inputFileName))
                     using (var outputStream = File.OpenWrite(outputFileName))
@@ -329,6 +329,30 @@
             }
 
             return new Pipeline(transformers);
+        }
+
+        private string GetOutputFileName(string inputFileName)
+        {
+            string baseFileName = Path.GetFileNameWithoutExtension(inputFileName);
+
+            try
+            {
+                string existingCulture = baseFileName.Split('.').LastOrDefault();
+
+                if (existingCulture != null &&
+                    !baseFileName.StartsWith(existingCulture) &&
+                    !string.Equals(CultureInfo.CreateSpecificCulture(existingCulture).TwoLetterISOLanguageName, "iv", StringComparison.Ordinal))
+                {
+                    baseFileName = baseFileName.Substring(0, baseFileName.LastIndexOf('.'));
+                }
+            }
+            catch (CultureNotFoundException)
+            {
+            }
+
+            return Path.Combine(
+                Path.GetDirectoryName(inputFileName),
+                baseFileName + "." + OutputCulture + Path.GetExtension(inputFileName));
         }
     }
 }

--- a/PseudoLocalize/Program.cs
+++ b/PseudoLocalize/Program.cs
@@ -37,6 +37,8 @@
             get { return _inputFiles.Count > 0; }
         }
 
+        public string OutputCulture { get; set; }
+
         public bool Overwrite { get; set; }
 
         public static void Main(string[] args)
@@ -48,13 +50,14 @@
             }
             else
             {
-                Console.WriteLine("Usage: pseudo-localize [/l] [/a] [/b] [/m] [/u] file [file...]");
+                Console.WriteLine("Usage: pseudo-localize [/l] [/a] [/b] [/m] [/u] [/c culture] file [file...]");
                 Console.WriteLine("Generates pseudo-localized versions of the specified input file(s).");
                 Console.WriteLine();
                 Console.WriteLine("The input files must be resource files in Resx or Xlf file format.");
                 Console.WriteLine("The output will be written to a file next to the original, with .qps-Ploc");
-                Console.WriteLine("appended to its name. For example, if the input file is X:\\Foo\\Bar.resx,");
-                Console.WriteLine("then the output file will be X:\\Foo\\Bar.qps-Ploc.resx.");
+                Console.WriteLine("(or the output culture you specify) appended to its name. For example, if");
+                Console.WriteLine("the input file is X:\\Foo\\Bar.resx, then the output file will be");
+                Console.WriteLine("X:\\Foo\\Bar.qps-Ploc.resx.");
                 Console.WriteLine();
                 Console.WriteLine("Options:");
                 Console.WriteLine("  /h, --help         Show command line help.");
@@ -64,6 +67,7 @@
                 Console.WriteLine("                     This makes it possible to spot cut off strings.");
                 Console.WriteLine("  /m, --mirror       Reverse all words (\"mirror\").");
                 Console.WriteLine("  /u, --underscores  Replace all characters with underscores.");
+                Console.WriteLine("  /c, --culture      Use the following string as the culture code in the output file name(s).");
                 Console.WriteLine("  /o, --overwrite    Overwrites the input file(s) with the pseudo-localized version.");
                 Console.WriteLine("  /f, --force        Suppresses the confirmation prompt for the --overwrite option.");
                 Console.WriteLine();
@@ -90,9 +94,12 @@
             instance.EnableBrackets = false;
             instance.EnableMirror = false;
             instance.EnableUnderscores = false;
+            instance.OutputCulture = "qps-Ploc";
 
-            foreach (var arg in args)
+            for (var i = 0; i < args.Length; i++)
             {
+                string arg = args[i];
+
                 // File paths may start with '/' on Linux,
                 // so if a path is a file, use it as such.
                 if (File.Exists(arg))
@@ -124,6 +131,26 @@
                         case "BRACKETS":
                             instance.EnableBrackets = true;
                             instance.UseDefaultOptions = false;
+                            break;
+
+                        case "C":
+                        case "CULTURE":
+                            if (i == args.Length -1)
+                            {
+                                Console.WriteLine("ERROR: No output culture specified.", arg);
+                                return false;
+                            }
+
+                            string culture = args[i + 1];
+                            if (culture.StartsWith("/", StringComparison.Ordinal) ||
+                                culture.StartsWith("-", StringComparison.Ordinal))
+                            {
+                                Console.WriteLine("ERROR: No output culture specified.", arg);
+                                return false;
+                            }
+
+                            instance.OutputCulture = culture;
+                            i++; // Consumed, so skip
                             break;
 
                         case "F":
@@ -181,7 +208,7 @@
 
             if (string.Equals(".xlf", extension, StringComparison.OrdinalIgnoreCase))
             {
-                return new XlfProcessor();
+                return new XlfProcessor(OutputCulture);
             }
             else
             {
@@ -232,7 +259,9 @@
                 }
                 else
                 {
-                    var outputFileName = Path.Combine(Path.GetDirectoryName(inputFileName), Path.GetFileNameWithoutExtension(inputFileName) + ".qps-Ploc" + Path.GetExtension(inputFileName));
+                    var outputFileName = Path.Combine(
+                        Path.GetDirectoryName(inputFileName),
+                        Path.GetFileNameWithoutExtension(inputFileName) + "." + OutputCulture + Path.GetExtension(inputFileName));
 
                     using (var inputStream = File.OpenRead(inputFileName))
                     using (var outputStream = File.OpenWrite(outputFileName))

--- a/PseudoLocalizer.Core.Tests/TransformTests.cs
+++ b/PseudoLocalizer.Core.Tests/TransformTests.cs
@@ -83,5 +83,14 @@
             var pipeline = new Pipeline(Array.Empty<ITransformer>());
             Assert.That(pipeline.Transform(string.Empty), Is.EqualTo(string.Empty));
         }
+
+        [Test]
+        public void ShouldIgnorePlaceholdersWhenApplyingUnderscores()
+        {
+            Assert.That(Underscores.Instance.Transform("{0}hello, world"), Is.EqualTo("{0}____________"));
+            Assert.That(Underscores.Instance.Transform("hello, {1} world"), Is.EqualTo("_______{1}______"));
+            Assert.That(Underscores.Instance.Transform("hello, world{99}"), Is.EqualTo("____________{99}"));
+            Assert.That(Underscores.Instance.Transform("hello, world{0"), Is.EqualTo("______________"));
+        }
     }
 }

--- a/PseudoLocalizer.Core/Underscores.cs
+++ b/PseudoLocalizer.Core/Underscores.cs
@@ -1,4 +1,6 @@
-﻿namespace PseudoLocalizer.Core
+﻿using System.Linq;
+
+namespace PseudoLocalizer.Core
 {
     /// <summary>
     /// A transform which replaces all characters with underscores. This class cannot be inherited.
@@ -12,6 +14,50 @@
 
         /// <inheritdoc />
         public string Transform(string value)
-            => new string('_', value.Length);
+        {
+            // Slower path to no break formatting strings by removing their digits
+            if (value.Contains('{') && value.Contains('}'))
+            {
+                char[] array = value.ToArray();
+
+                for (int i = 0; i < array.Length; i++)
+                {
+                    char ch = array[i];
+
+                    // Are we at the start of a potential placeholder (e.g. "{?...}")
+                    if (ch == '{' && i < array.Length - 2)
+                    {
+                        int j = i;
+
+                        // Consume all the digits
+                        while (j < array.Length - 1 && char.IsDigit(array[++j]))
+                        {
+                        }
+
+                        if (array[j] == ':')
+                        {
+                            // Consume all of any format specifier (e.g. "{0:yyyy}" for a DateTime)
+                            while (j < array.Length - 1 && array[++j] != '}')
+                            {
+                            }
+                        }
+
+                        if (array[j] == '}')
+                        {
+                            i = j;
+                            continue;
+                        }
+                    }
+
+                    array[i] = '_';
+                }
+
+                return new string(array);
+            }
+            else
+            {
+                return new string('_', value.Length);
+            }
+        }
     }
 }

--- a/PseudoLocalizer.Core/XlfProcessor.cs
+++ b/PseudoLocalizer.Core/XlfProcessor.cs
@@ -24,6 +24,9 @@
         /// Initializes a new instance of the <see cref="XlfProcessor"/> class.
         /// </summary>
         /// <param name="culture">The name of the culture to output.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="culture"/> is <see langword="null"/>.
+        /// </exception>
         public XlfProcessor(string culture)
         {
             Culture = culture ?? throw new ArgumentNullException(nameof(culture));

--- a/PseudoLocalizer.Core/XlfProcessor.cs
+++ b/PseudoLocalizer.Core/XlfProcessor.cs
@@ -12,6 +12,28 @@
     {
         private readonly IDictionary<XmlDocument, Version> _versionCache = new ConcurrentDictionary<XmlDocument, Version>();
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XlfProcessor"/> class.
+        /// </summary>
+        public XlfProcessor()
+            : this("qps-Ploc")
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XlfProcessor"/> class.
+        /// </summary>
+        /// <param name="culture">The name of the culture to output.</param>
+        public XlfProcessor(string culture)
+        {
+            Culture = culture ?? throw new ArgumentNullException(nameof(culture));
+        }
+
+        /// <summary>
+        /// Gets the culture code associated with the processor.
+        /// </summary>
+        public string Culture { get; }
+
         /// <inheritdoc />
         protected override void OnProcessed(XmlDocument document, XmlNamespaceManager nsmgr, bool modified)
         {
@@ -50,7 +72,7 @@
 
             if (attribute != null)
             {
-                attribute.Value = "qps-Ploc";
+                attribute.Value = Culture;
             }
         }
 


### PR DESCRIPTION
Port changes made to another fork of the tool:

  1. Allow the output culture to be specified, rather than always being `qps-Ploc`.
  1. If the input file name already ends in a valid culture name, it will be replaced with `qps-Ploc` instead of having `.qps-Ploc` appended to it.
  1. Apply fix for `Accents` when handling format placeholders to the `Underscores`  class too.
