### PR TITLE
Do not transform HTML tags

### DIFF
--- a/PseudoLocalizer.Core.Tests/TransformTests.cs
+++ b/PseudoLocalizer.Core.Tests/TransformTests.cs
@@ -65,7 +65,23 @@
         public void TestAccentsDoNotBreakFormatStrings(string input, string expected)
         {
             string actual = Accents.Instance.Transform(input);
-            Assert.That(actual.Contains(expected));
+            Assert.That(actual, Contains.Substring(expected));
+        }
+
+        [Test]
+        [TestCase("Hi <em>{0}</em>, click <a href=\"{1}\">here</a>.", new[] { "<em>{0}</em>", "<a href=\"{1}\">", "</a>" })]
+        [TestCase("2 > 0", new[] { "② ≥ ⓪" })]
+        [TestCase("0 < 2", new[] { "⓪ ≤ ②" })]
+        [TestCase("0 <> 2", new[] { "⓪ ≤≥ ②" })]
+        [TestCase("<self/> <a></a> <tag />", new[] { "<self/>", "<a></a>", "<tag />" })]
+        public void TestAccentsDoNotBreakHtml(string input, string[] expected)
+        {
+            string actual = Accents.Instance.Transform(input);
+
+            foreach (string value in expected)
+            {
+                Assert.That(actual, Contains.Substring(value));
+            }
         }
 
         [Test]
@@ -91,6 +107,14 @@
             Assert.That(Underscores.Instance.Transform("hello, {1} world"), Is.EqualTo("_______{1}______"));
             Assert.That(Underscores.Instance.Transform("hello, world{99}"), Is.EqualTo("____________{99}"));
             Assert.That(Underscores.Instance.Transform("hello, world{0"), Is.EqualTo("______________"));
+        }
+
+        [Test]
+        public void ShouldIgnoreHtmlWhenApplyingUnderscores()
+        {
+            Assert.That(Underscores.Instance.Transform("This <em>is</em> Sparta"), Is.EqualTo("_____<em>__</em>_______"));
+            Assert.That(Underscores.Instance.Transform("Some text <div/> more text"), Is.EqualTo("__________<div/>__________"));
+            Assert.That(Underscores.Instance.Transform("Some text <> more text"), Is.EqualTo("______________________"));
         }
     }
 }

--- a/PseudoLocalizer.Core/Accents.cs
+++ b/PseudoLocalizer.Core/Accents.cs
@@ -135,8 +135,9 @@
         /// <inheritdoc />
         public string Transform(string value)
         {
-            // Slower path to no break formatting strings by removing their digits
-            if (value.Contains('{') && value.Contains('}'))
+            // Slower path to not break formatting strings by removing their digits or break HTML tags
+            if ((value.Contains('{') && value.Contains('}')) ||
+                (value.Contains('<') && value.Contains('>') && value.Contains('/')))
             {
                 char[] array = value.ToArray();
 
@@ -144,32 +145,10 @@
                 {
                     char ch = array[i];
 
-                    // Are we at the start of a potential placeholder (e.g. "{?...}")
-                    if (ch == '{' && i < array.Length - 2)
+                    if (EscapeHelpers.ShouldTransform(array, ch, ref i))
                     {
-                        int j = i;
-
-                        // Consume all the digits
-                        while (j < array.Length - 1 && char.IsDigit(array[++j]))
-                        {
-                        }
-
-                        if (array[j] == ':')
-                        {
-                            // Consume all of any format specifier (e.g. "{0:yyyy}" for a DateTime)
-                            while (j < array.Length - 1 && array[++j] != '}')
-                            {
-                            }
-                        }
-
-                        if (array[j] == '}')
-                        {
-                            i = j;
-                            continue;
-                        }
+                        array[i] = Transform(ch);
                     }
-
-                    array[i] = Transform(ch);
                 }
 
                 return new string(array);

--- a/PseudoLocalizer.Core/EscapeHelpers.cs
+++ b/PseudoLocalizer.Core/EscapeHelpers.cs
@@ -1,0 +1,56 @@
+﻿namespace PseudoLocalizer.Core
+{
+    internal static class EscapeHelpers
+    {
+        internal static bool ShouldTransform(char[] array, char ch, ref int i)
+        {
+            // Are we at the start of a potential placeholder (e.g. "{?...}")
+            if (ch == '{' && i < array.Length - 2)
+            {
+                int j = i;
+
+                // Consume all the digits
+                while (j < array.Length - 1 && char.IsDigit(array[++j]))
+                {
+                }
+
+                if (array[j] == ':')
+                {
+                    // Consume all of any format specifier (e.g. "{0:yyyy}" for a DateTime)
+                    while (j < array.Length - 1 && array[++j] != '}')
+                    {
+                    }
+                }
+
+                if (array[j] == '}')
+                {
+                    i = j;
+                    return false;
+                }
+            }
+            else if (ch == '<' && i < array.Length - 2)
+            {
+                // Are we at the start of a potential HTML tag (e.g. "<a/>")
+                int j = i;
+
+                char next = array[i + 1];
+
+                if ((next >= 'a' && next <= 'z') || (next >= 'A' && next <= 'Z') || next == '/')
+                {
+                    // Consume all of the tag
+                    while (j < array.Length - 1 && array[++j] != '>')
+                    {
+                    }
+
+                    if (array[j] == '>')
+                    {
+                        i = j;
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/PseudoLocalizer.Core/Underscores.cs
+++ b/PseudoLocalizer.Core/Underscores.cs
@@ -15,8 +15,9 @@ namespace PseudoLocalizer.Core
         /// <inheritdoc />
         public string Transform(string value)
         {
-            // Slower path to no break formatting strings by removing their digits
-            if (value.Contains('{') && value.Contains('}'))
+            // Slower path to not break formatting strings by removing their digits or break HTML tags
+            if ((value.Contains('{') && value.Contains('}')) ||
+                (value.Contains('<') && value.Contains('>') && value.Contains('/')))
             {
                 char[] array = value.ToArray();
 
@@ -24,32 +25,10 @@ namespace PseudoLocalizer.Core
                 {
                     char ch = array[i];
 
-                    // Are we at the start of a potential placeholder (e.g. "{?...}")
-                    if (ch == '{' && i < array.Length - 2)
+                    if (EscapeHelpers.ShouldTransform(array, ch, ref i))
                     {
-                        int j = i;
-
-                        // Consume all the digits
-                        while (j < array.Length - 1 && char.IsDigit(array[++j]))
-                        {
-                        }
-
-                        if (array[j] == ':')
-                        {
-                            // Consume all of any format specifier (e.g. "{0:yyyy}" for a DateTime)
-                            while (j < array.Length - 1 && array[++j] != '}')
-                            {
-                            }
-                        }
-
-                        if (array[j] == '}')
-                        {
-                            i = j;
-                            continue;
-                        }
+                        array[i] = '_';
                     }
-
-                    array[i] = '_';
                 }
 
                 return new string(array);


### PR DESCRIPTION
Add a naive implementation that would not break HTML tags in the `Accents` and `Underscores` transformations.

Resolves #6.