### PR TITLE
More HTML fixes

### DIFF
--- a/PseudoLocalize.Tests/localized.xlf
+++ b/PseudoLocalize.Tests/localized.xlf
@@ -9,12 +9,12 @@
       </trans-unit>
       <trans-unit id="PageTitleFormat">
         <source>{0} - {1}</source>
-        <target state="translated">[{0}ẋ ‐ẋ {1}ẋ]</target>
+        <target state="translated">[{0} ‐ẋ {1}]</target>
         <note />
       </trans-unit>
       <trans-unit id="Copyright">
         <source>© {0:yyyy} - {1}</source>
-        <target state="translated">[©ẋ {0:yyyy}ẋẋẋ ‐ẋ {1}ẋ]</target>
+        <target state="translated">[©ẋ {0:yyyy} ‐ẋ {1}]</target>
         <note />
       </trans-unit>
       <trans-unit id="NavListText">

--- a/PseudoLocalizer.Core.Tests/TransformTests.cs
+++ b/PseudoLocalizer.Core.Tests/TransformTests.cs
@@ -73,7 +73,7 @@
         [TestCase("2 > 0", new[] { "② ≥ ⓪" })]
         [TestCase("0 < 2", new[] { "⓪ ≤ ②" })]
         [TestCase("0 <> 2", new[] { "⓪ ≤≥ ②" })]
-        [TestCase("<self/> <a></a> <tag />", new[] { "<self/>", "<a></a>", "<tag />" })]
+        [TestCase("<self/> <br> <a></a> <tag /> <br>", new[] { "<self/>", "<br>", "<a></a>", "<tag />" })]
         public void TestAccentsDoNotBreakHtml(string input, string[] expected)
         {
             string actual = Accents.Instance.Transform(input);

--- a/PseudoLocalizer.Core.Tests/TransformTests.cs
+++ b/PseudoLocalizer.Core.Tests/TransformTests.cs
@@ -85,6 +85,21 @@
         }
 
         [Test]
+        [TestCase("Hi <em>{0}</em>, click <a href=\"{1}\">here</a>.", new[] { "<em>{0}</em>", "<a href=\"{1}\">", "</a>" })]
+        [TestCase("<em>{0}</em>", new[] { "<em>{0}</em>" })]
+        [TestCase("<em> {0} </em>", new[] { "<em> {0} </em>" })]
+        [TestCase("<a href=\"{0}\">here</a>", new[] { "<a href=\"{0}\">" })]
+        public void TestExtraLengthDoesNotBreakHtml(string input, string[] expected)
+        {
+            string actual = ExtraLength.Instance.Transform(input);
+
+            foreach (string value in expected)
+            {
+                Assert.That(actual, Contains.Substring(value));
+            }
+        }
+
+        [Test]
         public void TestPipeline()
         {
             var pipeline = new Pipeline(ExtraLength.Instance, Accents.Instance, Brackets.Instance);

--- a/PseudoLocalizer.Core/Accents.cs
+++ b/PseudoLocalizer.Core/Accents.cs
@@ -138,8 +138,7 @@
             char[] array;
 
             // Slower path to not break formatting strings by removing their digits or break HTML tags
-            if ((value.Contains('{') && value.Contains('}')) ||
-                (value.Contains('<') && value.Contains('>')))
+            if (EscapeHelpers.MayNeedEscaping(value))
             {
                 array = value.ToArray();
 

--- a/PseudoLocalizer.Core/Accents.cs
+++ b/PseudoLocalizer.Core/Accents.cs
@@ -135,11 +135,13 @@
         /// <inheritdoc />
         public string Transform(string value)
         {
+            char[] array;
+
             // Slower path to not break formatting strings by removing their digits or break HTML tags
             if ((value.Contains('{') && value.Contains('}')) ||
                 (value.Contains('<') && value.Contains('>') && value.Contains('/')))
             {
-                char[] array = value.ToArray();
+                array = value.ToArray();
 
                 for (int i = 0; i < array.Length; i++)
                 {
@@ -150,16 +152,13 @@
                         array[i] = Transform(ch);
                     }
                 }
-
-                return new string(array);
             }
             else
             {
-                return new string(
-                    value.ToCharArray()
-                        .Select(x => Transform(x))
-                        .ToArray());
+                array = value.Select(Transform).ToArray();
             }
+
+            return new string(array);
         }
 
         /// <summary>

--- a/PseudoLocalizer.Core/Accents.cs
+++ b/PseudoLocalizer.Core/Accents.cs
@@ -139,7 +139,7 @@
 
             // Slower path to not break formatting strings by removing their digits or break HTML tags
             if ((value.Contains('{') && value.Contains('}')) ||
-                (value.Contains('<') && value.Contains('>') && value.Contains('/')))
+                (value.Contains('<') && value.Contains('>')))
             {
                 array = value.ToArray();
 

--- a/PseudoLocalizer.Core/EscapeHelpers.cs
+++ b/PseudoLocalizer.Core/EscapeHelpers.cs
@@ -1,7 +1,15 @@
-﻿namespace PseudoLocalizer.Core
+﻿using System.Linq;
+
+namespace PseudoLocalizer.Core
 {
     internal static class EscapeHelpers
     {
+        internal static bool MayNeedEscaping(string value)
+        {
+            return (value.Contains('{') && value.Contains('}')) ||
+                   (value.Contains('<') && value.Contains('>'));
+        }
+
         internal static bool ShouldTransform(char[] array, char ch, ref int i)
         {
             // Are we at the start of a potential placeholder (e.g. "{?...}")

--- a/PseudoLocalizer.Core/ExtraLength.cs
+++ b/PseudoLocalizer.Core/ExtraLength.cs
@@ -1,6 +1,8 @@
 ﻿namespace PseudoLocalizer.Core
 {
+    using System.Collections.Generic;
     using System.Linq;
+    using System.Text;
 
     /// <summary>
     /// A transform which makes all words approximately one third longer. This class cannot be inherited.
@@ -15,11 +17,59 @@
         /// <inheritdoc />
         public string Transform(string value)
         {
-            return string.Join(
-                " ", 
-                value.Split(' ')
-                    .Select(word => Lengthen(word)));
+            IEnumerable<string> words;
+
+            // Slower path to not break formatting strings by removing their digits or break HTML tags
+            if (EscapeHelpers.MayNeedEscaping(value))
+            {
+                char[] src = value.ToArray();
+
+                var builder = new StringBuilder(value.Length * 2);
+                var current = new StringBuilder(value.Length);
+
+                for (int i = 0; i < value.Length; i++)
+                {
+                    char ch = value[i];
+                    int indexBefore = i;
+
+                    if (EscapeHelpers.ShouldTransform(src, ch, ref i))
+                    {
+                        current.Append(ch);
+                    }
+                    else
+                    {
+                        // Transformation should be skipped due to formatting placeholder or HTML
+                        if (current.Length > 0)
+                        {
+                            builder.Append(Lengthen(current));
+                            current.Clear();
+                        }
+
+                        // Add the skipped range
+                        for (int j = indexBefore; j < i + 1; j++)
+                        {
+                            builder.Append(value[j]);
+                        }
+                    }
+                }
+
+                if (current.Length > 0)
+                {
+                    builder.Append(Lengthen(current));
+                }
+
+                return builder.ToString();
+            }
+            else
+            {
+                words = value.Split(' ').Select(Lengthen);
+            }
+
+            return string.Join(" ", words);
         }
+
+        private static string Lengthen(StringBuilder builder)
+            => string.Join(" ", builder.ToString().Split(' ').Select(Lengthen));
 
         private static string Lengthen(string word)
         {

--- a/PseudoLocalizer.Core/Underscores.cs
+++ b/PseudoLocalizer.Core/Underscores.cs
@@ -16,8 +16,7 @@ namespace PseudoLocalizer.Core
         public string Transform(string value)
         {
             // Slower path to not break formatting strings by removing their digits or break HTML tags
-            if ((value.Contains('{') && value.Contains('}')) ||
-                (value.Contains('<') && value.Contains('>')))
+            if (EscapeHelpers.MayNeedEscaping(value))
             {
                 char[] array = value.ToArray();
 

--- a/PseudoLocalizer.Core/Underscores.cs
+++ b/PseudoLocalizer.Core/Underscores.cs
@@ -17,7 +17,7 @@ namespace PseudoLocalizer.Core
         {
             // Slower path to not break formatting strings by removing their digits or break HTML tags
             if ((value.Contains('{') && value.Contains('}')) ||
-                (value.Contains('<') && value.Contains('>') && value.Contains('/')))
+                (value.Contains('<') && value.Contains('>')))
             {
                 char[] array = value.ToArray();
 


### PR DESCRIPTION
More HTML fixes.

- [x] Handle HTML tags written like `<br>` where a `/` isn't strictly required.
- [ ] Do not lengthen HTML tags like `<a href="">`.

Resolves #6.

Also includes some refactoring.