### PR TITLE
Workaround PackageLicenseExpression support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,11 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageIconUrl></PackageIconUrl>
+    <NoWarn>$(NoWarn);NU5125</NoWarn>
+    <!--
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    -->
+    <PackageLicenseUrl>https://github.com/martincostello/Pseudolocalizer#license</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/martincostello/Pseudolocalizer</PackageProjectUrl>
     <PackageReleaseNotes>See $(PackageProjectUrl)/releases for details.</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Remove usage of `PackageLicenseExpression` add by #9 for now (and thus suppress `NU5125`) until NuGet.org supports it for package uploads.