### PR TITLE
Use PackageLicenseExpression

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,11 +14,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageIconUrl></PackageIconUrl>
-    <NoWarn>$(NoWarn);NU5125</NoWarn>
-    <!--
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    -->
-    <PackageLicenseUrl>https://github.com/martincostello/Pseudolocalizer#license</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/martincostello/Pseudolocalizer</PackageProjectUrl>
     <PackageReleaseNotes>See $(PackageProjectUrl)/releases for details.</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Restore the usage of `PackageLicenseExpression`.