### PR TITLE
Use legacy symbol package format

### DIFF
--- a/PseudoLocalize/PseudoLocalize.csproj
+++ b/PseudoLocalize/PseudoLocalize.csproj
@@ -6,6 +6,8 @@
     <PackAsTool>true</PackAsTool>
     <PackageId>PseudoLocalize</PackageId>
     <Summary>$(Description)</Summary>
+    <!-- Work around https://github.com/NuGet/NuGetGallery/issues/6743 -->
+    <SymbolPackageFormat>symbols.nupkg</SymbolPackageFormat>
     <TargetFrameworks>netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <Title>PseudoLocalize</Title>
     <ToolCommandName>pseudo-localize</ToolCommandName>


### PR DESCRIPTION
Use the old symbol package format for the global tool to work around https://github.com/NuGet/NuGetGallery/issues/6743.