### PR TITLE
Update Humanizer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,7 @@
     <Company>https://github.com/martincostello/Pseudolocalizer</Company>
     <ContinuousIntegrationBuild Condition=" '$(CI)' != '' ">true</ContinuousIntegrationBuild>
     <Copyright>Pseudolocalizer Contributors (c) 2012-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
+    <Deterministic>true</Deterministic>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <LangVersion>latest</LangVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <Copyright>Pseudolocalizer Contributors (c) 2012-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <Deterministic>true</Deterministic>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <LangVersion>latest</LangVersion>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,8 +27,8 @@
     <SignAssembly>true</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AssemblyVersion>0.3.0.0</AssemblyVersion>
-    <VersionPrefix>0.3.1</VersionPrefix>
+    <AssemblyVersion>0.4.0.0</AssemblyVersion>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' ">beta-$([System.Convert]::ToInt32(`$(GITHUB_RUN_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>

--- a/PseudoLocalize.Tests/PseudoLocalize.Tests.csproj
+++ b/PseudoLocalize.Tests/PseudoLocalize.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>PseudoLocalizer</RootNamespace>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />

--- a/PseudoLocalize/PseudoLocalize.csproj
+++ b/PseudoLocalize/PseudoLocalize.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <PackageId>PseudoLocalize</PackageId>
     <Summary>$(Description)</Summary>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <Title>PseudoLocalize</Title>
     <ToolCommandName>pseudo-localize</ToolCommandName>
   </PropertyGroup>

--- a/PseudoLocalizer.Core.Tests/PseudoLocalizer.Core.Tests.csproj
+++ b/PseudoLocalizer.Core.Tests/PseudoLocalizer.Core.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>PseudoLocalizer.Core.Tests</RootNamespace>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />

--- a/PseudoLocalizer.Humanizer/PseudoFormatter.cs
+++ b/PseudoLocalizer.Humanizer/PseudoFormatter.cs
@@ -50,6 +50,10 @@ namespace PseudoLocalizer.Humanizer
         private ITransformer Transformer { get; }
 
         /// <inheritdoc />
+        public string DataUnitHumanize(DataUnit dataUnit, double count, bool toSymbol = true)
+            => Transformer.Transform(Inner.DataUnitHumanize(dataUnit, count, toSymbol));
+
+        /// <inheritdoc />
         public string DateHumanize(TimeUnit timeUnit, Tense timeUnitTense, int unit)
             => Transformer.Transform(Inner.DateHumanize(timeUnit, timeUnitTense, unit));
 

--- a/PseudoLocalizer.Humanizer/PseudoLocalizer.Humanizer.csproj
+++ b/PseudoLocalizer.Humanizer/PseudoLocalizer.Humanizer.csproj
@@ -11,7 +11,7 @@
     <Title>PseudoLocalizer.Humanizer</Title>
   </PropertyGroup>
 <ItemGroup>
-  <PackageReference Include="Humanizer" Version="2.4.2" />
+  <PackageReference Include="Humanizer" Version="2.10.1" />
 </ItemGroup>
 <ItemGroup>
   <ProjectReference Include="..\PseudoLocalizer.Core\PseudoLocalizer.Core.csproj" />

--- a/PseudoLocalizer.Humanizer/PseudoNumberToWordsConverter.cs
+++ b/PseudoLocalizer.Humanizer/PseudoNumberToWordsConverter.cs
@@ -51,11 +51,15 @@ namespace PseudoLocalizer.Humanizer
 
         /// <inheritdoc />
         public string Convert(long number)
-                => Transformer.Transform(Inner.Convert(number));
+            => Transformer.Transform(Inner.Convert(number));
 
         /// <inheritdoc />
-        public string Convert(long number, GrammaticalGender gender)
-            => Transformer.Transform(Inner.Convert(number, gender));
+        public string Convert(long number, bool addAnd)
+            => Transformer.Transform(Inner.Convert(number, addAnd));
+
+        /// <inheritdoc />
+        public string Convert(long number, GrammaticalGender gender, bool addAnd = true)
+            => Transformer.Transform(Inner.Convert(number, gender, addAnd));
 
         /// <inheritdoc />
         public string ConvertToOrdinal(int number)

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.408",
+    "version": "5.0.202",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }


### PR DESCRIPTION
Update to the latest release of Humanizer as binary breaking changes since 2.4.2 have now made PseudoLocalizer.Humanizer stop working ([example](https://github.com/martincostello/aspnet-core-pseudo-localization/pull/143)).

Also:
  * Bumps the version to 0.4.0
  * Enables deterministic builds
  * Enables .NET SDK analyzers
