### PR TITLE
Update Humanizer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,8 +29,8 @@
     <SignAssembly>true</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AssemblyVersion>0.6.0.0</AssemblyVersion>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <AssemblyVersion>0.7.0.0</AssemblyVersion>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' ">beta-$([System.Convert]::ToInt32(`$(GITHUB_RUN_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>

--- a/PseudoLocalizer.Core.Tests/PseudoLocalizer.Core.Tests.csproj
+++ b/PseudoLocalizer.Core.Tests/PseudoLocalizer.Core.Tests.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/PseudoLocalizer.Humanizer/PseudoLocalizer.Humanizer.csproj
+++ b/PseudoLocalizer.Humanizer/PseudoLocalizer.Humanizer.csproj
@@ -11,7 +11,7 @@
     <Title>PseudoLocalizer.Humanizer</Title>
   </PropertyGroup>
 <ItemGroup>
-  <PackageReference Include="Humanizer" Version="2.13.14" />
+  <PackageReference Include="Humanizer" Version="2.14.1" />
 </ItemGroup>
 <ItemGroup>
   <ProjectReference Include="..\PseudoLocalizer.Core\PseudoLocalizer.Core.csproj" />

--- a/PseudoLocalizer.Humanizer/PseudoNumberToWordsConverter.cs
+++ b/PseudoLocalizer.Humanizer/PseudoNumberToWordsConverter.cs
@@ -54,20 +54,40 @@ namespace PseudoLocalizer.Humanizer
             => Transformer.Transform(Inner.Convert(number));
 
         /// <inheritdoc />
+        public string Convert(long number, WordForm wordForm)
+            => Transformer.Transform(Inner.Convert(number, wordForm));
+
+        /// <inheritdoc />
         public string Convert(long number, bool addAnd)
             => Transformer.Transform(Inner.Convert(number, addAnd));
+
+        /// <inheritdoc />
+        public string Convert(long number, bool addAnd, WordForm wordForm)
+            => Transformer.Transform(Inner.Convert(number, addAnd, wordForm));
 
         /// <inheritdoc />
         public string Convert(long number, GrammaticalGender gender, bool addAnd = true)
             => Transformer.Transform(Inner.Convert(number, gender, addAnd));
 
         /// <inheritdoc />
+        public string Convert(long number, WordForm wordForm, GrammaticalGender gender, bool addAnd = true)
+            => Transformer.Transform(Inner.Convert(number, wordForm, gender, addAnd));
+
+        /// <inheritdoc />
         public string ConvertToOrdinal(int number)
             => Transformer.Transform(Inner.ConvertToOrdinal(number));
 
         /// <inheritdoc />
+        public string ConvertToOrdinal(int number, WordForm wordForm)
+            => Transformer.Transform(Inner.ConvertToOrdinal(number, wordForm));
+
+        /// <inheritdoc />
         public string ConvertToOrdinal(int number, GrammaticalGender gender)
             => Transformer.Transform(Inner.ConvertToOrdinal(number, gender));
+
+        /// <inheritdoc />
+        public string ConvertToOrdinal(int number, GrammaticalGender gender, WordForm wordForm)
+            => Transformer.Transform(Inner.ConvertToOrdinal(number, gender, wordForm));
 
         /// <inheritdoc />
         public string ConvertToTuple(int number)

--- a/PseudoLocalizer.Humanizer/PseudoOrdinalizer.cs
+++ b/PseudoLocalizer.Humanizer/PseudoOrdinalizer.cs
@@ -54,7 +54,15 @@ namespace PseudoLocalizer.Humanizer
             => Transformer.Transform(Inner.Convert(number, numberString));
 
         /// <inheritdoc />
+        public string Convert(int number, string numberString, WordForm wordForm)
+            => Transformer.Transform(Inner.Convert(number, numberString, wordForm));
+
+        /// <inheritdoc />
         public string Convert(int number, string numberString, GrammaticalGender gender)
             => Transformer.Transform(Inner.Convert(number, numberString, gender));
+
+        /// <inheritdoc />
+        public string Convert(int number, string numberString, GrammaticalGender gender, WordForm wordForm)
+            => Transformer.Transform(Inner.Convert(number, numberString, gender, wordForm));
     }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -18,14 +18,14 @@ $solutionFile = Join-Path $solutionPath "PseudoLocalizer.sln"
 $sdkFile = Join-Path $solutionPath "global.json"
 
 $packageProjects = @(
-	(Join-Path $solutionPath "PseudoLocalizer.Core\PseudoLocalizer.Core.csproj"),
-	(Join-Path $solutionPath "PseudoLocalizer.Humanizer\PseudoLocalizer.Humanizer.csproj"),
-	(Join-Path $solutionPath "PseudoLocalize\PseudoLocalize.csproj")
+	(Join-Path $solutionPath "PseudoLocalizer.Core" "PseudoLocalizer.Core.csproj"),
+	(Join-Path $solutionPath "PseudoLocalizer.Humanizer" "PseudoLocalizer.Humanizer.csproj"),
+	(Join-Path $solutionPath "PseudoLocalize" "PseudoLocalize.csproj")
 )
 
 $testProjects = @(
-    (Join-Path $solutionPath "PseudoLocalizer.Core.Tests\PseudoLocalizer.Core.Tests.csproj"),
-    (Join-Path $solutionPath "PseudoLocalize.Tests\PseudoLocalize.Tests.csproj")
+    (Join-Path $solutionPath "PseudoLocalizer.Core.Tests" "PseudoLocalizer.Core.Tests.csproj"),
+    (Join-Path $solutionPath "PseudoLocalize.Tests" "PseudoLocalize.Tests.csproj")
 )
 
 $dotnetVersion = (Get-Content $sdkFile | Out-String | ConvertFrom-Json).sdk.version
@@ -57,7 +57,7 @@ else {
 if ($installDotNetSdk -eq $true) {
 
     $env:DOTNET_INSTALL_DIR = Join-Path "$(Convert-Path "$PSScriptRoot")" ".dotnetcli"
-    $sdkPath = Join-Path $env:DOTNET_INSTALL_DIR "sdk\$dotnetVersion"
+    $sdkPath = Join-Path $env:DOTNET_INSTALL_DIR "sdk" "$dotnetVersion"
 
     if (!(Test-Path $sdkPath)) {
         if (!(Test-Path $env:DOTNET_INSTALL_DIR)) {

--- a/build.ps1
+++ b/build.ps1
@@ -115,7 +115,14 @@ function DotNetPack {
 function DotNetTest {
     param([string]$Project)
 
-    & $dotnet test $Project --output $OutputPath --no-build
+    $additionalArgs = @()
+
+    if (![string]::IsNullOrEmpty($env:GITHUB_SHA)) {
+        $additionalArgs += "--logger"
+        $additionalArgs += "GitHubActions;report-warnings=false"
+    }
+
+    & $dotnet test $Project --output $OutputPath --configuration $Configuration --no-build $additionalArgs
 
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet test failed with exit code $LASTEXITCODE"

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,8 @@
 #! /usr/bin/env pwsh
+
+#Requires -PSEdition Core
+#Requires -Version 7
+
 param(
     [Parameter(Mandatory = $false)][string] $Configuration = "Release",
     [Parameter(Mandatory = $false)][string] $VersionSuffix = "",


### PR DESCRIPTION
* Bumps Humanizer from 2.13.14 to 2.14.1.
* Add GitHubActionsTestLogger for use with dotnet test in CI.
* Update the build script to require PowerShell Core.
* Update `Join-Path` usage to remove path separators.
* Bump version to 0.7.0.
