### PR TITLE
Support .NET 7

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -3,7 +3,7 @@
   "components": [
     "Microsoft.VisualStudio.Component.CoreEditor",
     "Microsoft.VisualStudio.Workload.CoreEditor",
-    "Microsoft.NetCore.Component.Runtime.6.0",
+    "Microsoft.NetCore.Component.Runtime.7.0",
     "Microsoft.NetCore.Component.SDK",
     "Microsoft.VisualStudio.Component.Roslyn.Compiler",
     "Microsoft.VisualStudio.Component.Roslyn.LanguageServices"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,8 +29,8 @@
     <SignAssembly>true</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AssemblyVersion>0.7.0.0</AssemblyVersion>
-    <VersionPrefix>0.7.0</VersionPrefix>
+    <AssemblyVersion>0.8.0.0</AssemblyVersion>
+    <VersionPrefix>0.8.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' ">beta-$([System.Convert]::ToInt32(`$(GITHUB_RUN_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>

--- a/PseudoLocalize.Tests/PseudoLocalize.Tests.csproj
+++ b/PseudoLocalize.Tests/PseudoLocalize.Tests.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="16.0">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>PseudoLocalizer</RootNamespace>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />

--- a/PseudoLocalize/PseudoLocalize.csproj
+++ b/PseudoLocalize/PseudoLocalize.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <PackageId>PseudoLocalize</PackageId>
     <Summary>$(Description)</Summary>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Title>PseudoLocalize</Title>
     <ToolCommandName>pseudo-localize</ToolCommandName>
   </PropertyGroup>

--- a/PseudoLocalizer.Core.Tests/PseudoLocalizer.Core.Tests.csproj
+++ b/PseudoLocalizer.Core.Tests/PseudoLocalizer.Core.Tests.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="16.0">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>PseudoLocalizer.Core.Tests</RootNamespace>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.403",
+    "version": "7.0.100",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }


### PR DESCRIPTION
- Add support for `net7.0`.
- Drop support for `netcoreapp3.1` and `net5.0`.
