### PR TITLE
Actionlint and feedz.io

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,13 +90,17 @@ jobs:
           Write-Output "::error::$invalidPackages NuGet package(s) failed validation."
         }
 
-  publish-myget:
+  publish-feedz-io:
     needs: validate-packages
     runs-on: ubuntu-latest
     if: |
       github.event.repository.fork == false &&
       (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
        startsWith(github.ref, 'refs/tags/v'))
+
+    environment:
+      name: feedz.io
+
     steps:
 
     - name: Download packages
@@ -107,8 +111,8 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
 
-    - name: Push NuGet packages to MyGet
-      run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.MYGET_TOKEN }} --skip-duplicate --source https://www.myget.org/F/martincostello/api/v2/package
+    - name: Push NuGet packages to feedz.io
+      run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.FEEDZ_IO_TOKEN }} --skip-duplicate --source https://f.feedz.io/${{ github.repository }}/nuget/index.json
 
   publish-nuget:
     needs: validate-packages
@@ -116,6 +120,10 @@ jobs:
     if: |
       github.event.repository.fork == false &&
       startsWith(github.ref, 'refs/tags/v')
+
+    environment:
+      name: NuGet.org
+
     steps:
 
     - name: Download packages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,40 @@
+name: lint
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+    - '**/*.gitattributes'
+    - '**/*.gitignore'
+    - '**/*.md'
+  pull_request:
+    branches:
+      - main
+      - dotnet-vnext
+      - dotnet-nightly
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: 3
+  TERM: xterm
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+    - name: Lint workflows
+      shell: bash
+      env:
+        ACTIONLINT_VERSION: '7b75d16d41920ec126e6f3269db0c6f3ab613c38' # v1.6.25
+      run: |
+        echo "::add-matcher::.github/actionlint-matcher.json"
+        bash <(curl --silent --show-error "https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_VERSION}/scripts/download-actionlint.bash")
+        ./actionlint -color


### PR DESCRIPTION
- Publish pre-release packages to feedz.io instead of MyGet.
- Add environments for NuGet package publishing.
- Add a GitHub Actions workflow to lint actions.
