### PR TITLE
Use SHA-256 for checksums

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,7 @@
     <Authors>anderskaplan;martin_costello</Authors>
     <!-- HACK Workaround flaky builds in CI -->
     <BuildInParallel Condition=" $([MSBuild]::IsOSUnixLike()) and '$(CI)' != '' ">false</BuildInParallel>
+    <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
     <Company>https://github.com/martincostello/Pseudolocalizer</Company>
     <ContinuousIntegrationBuild Condition=" '$(CI)' != '' ">true</ContinuousIntegrationBuild>
     <Copyright>Pseudolocalizer Contributors (c) 2012-$([System.DateTime]::Now.ToString(yyyy))</Copyright>


### PR DESCRIPTION
Fix `BA2004` warning from Binskim.
