### PR TITLE
Pin .NET SDK version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
+    outputs:
+      dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -43,6 +46,7 @@ jobs:
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+      id: setup-dotnet
 
     - name: Build, Test and Package
       shell: pwsh
@@ -73,6 +77,8 @@ jobs:
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+      with:
+        dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Validate NuGet packages
       shell: pwsh
@@ -91,7 +97,7 @@ jobs:
         }
 
   publish-feedz-io:
-    needs: validate-packages
+    needs: [ build, validate-packages ]
     runs-on: ubuntu-latest
     if: |
       github.repository_owner == 'martincostello' &&
@@ -110,6 +116,8 @@ jobs:
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+      with:
+        dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Push NuGet packages to feedz.io
       shell: bash
@@ -119,7 +127,7 @@ jobs:
       run: dotnet nuget push "*.nupkg" --api-key "${API_KEY}" --skip-duplicate --source "${SOURCE}"
 
   publish-nuget:
-    needs: validate-packages
+    needs: [ build, validate-packages ]
     runs-on: ubuntu-latest
     if: |
       github.repository_owner == 'martincostello' &&
@@ -137,6 +145,8 @@ jobs:
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+      with:
+        dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Push NuGet packages to NuGet.org
       shell: bash


### PR DESCRIPTION
Use the same .NET SDK version to publish NuGet packages as to build them where there is no global.json to specify it.