### PR TITLE
Attest artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: packages-${{ matrix.os_name }}
-        path: ./artifacts/packages
+        path: ./artifacts/package/release
         if-no-files-found: error
 
   validate-packages:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,8 @@ jobs:
 
     - name: Attest artifacts
       uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4 # v1.1.1
-      #if: |
-      #  runner.os == 'Windows' &&
+      if: |
+        runner.os == 'Windows'
       #  github.event.repository.fork == false &&
       #  (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,11 @@ jobs:
     outputs:
       dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
 
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -51,6 +56,19 @@ jobs:
     - name: Build, Test and Package
       shell: pwsh
       run: ./build.ps1
+
+    - name: Attest artifacts
+      uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4 # v1.1.1
+      #if: |
+      #  runner.os == 'Windows' &&
+      #  github.event.repository.fork == false &&
+      #  (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
+      with:
+        subject-path: |
+          ./artifacts/bin/PseudoLocalize/release*/PseudoLocalize*.dll
+          ./artifacts/bin/PseudoLocalize/release*/PseudoLocalize*.exe
+          ./artifacts/bin/PseudoLocalize.Core/release*/PseudoLocalize*.dll
+          ./artifacts/bin/PseudoLocalizer.Humanizer/release*/PseudoLocalize*.dll
 
     - name: Publish artifacts
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,15 +60,16 @@ jobs:
     - name: Attest artifacts
       uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4 # v1.1.1
       if: |
-        runner.os == 'Windows'
-      #  github.event.repository.fork == false &&
-      #  (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
+        runner.os == 'Windows' &&
+        github.event.repository.fork == false &&
+        (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
       with:
         subject-path: |
           ./artifacts/bin/PseudoLocalize/release*/PseudoLocalize*.dll
           ./artifacts/bin/PseudoLocalize/release*/PseudoLocalize*.exe
           ./artifacts/bin/PseudoLocalize.Core/release*/PseudoLocalize*.dll
           ./artifacts/bin/PseudoLocalizer.Humanizer/release*/PseudoLocalize*.dll
+          ./artifacts/package/release/*
 
     - name: Publish artifacts
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
         subject-path: |
           ./artifacts/bin/PseudoLocalize/release*/PseudoLocalize*.dll
           ./artifacts/bin/PseudoLocalize/release*/PseudoLocalize*.exe
-          ./artifacts/bin/PseudoLocalize.Core/release*/PseudoLocalize*.dll
+          ./artifacts/bin/PseudoLocalizer.Core/release*/PseudoLocalize*.dll
           ./artifacts/bin/PseudoLocalizer.Humanizer/release*/PseudoLocalize*.dll
           ./artifacts/package/release/*
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage*
 obj
 TestResults
 TestResult.xml
+*.binlog
 *.cache
 *.coverage
 *.qps-Ploc.*

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,6 +30,7 @@
     <SignAssembly>true</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
     <AssemblyVersion>0.9.0.0</AssemblyVersion>
     <VersionPrefix>0.9.1</VersionPrefix>
   </PropertyGroup>

--- a/build.ps1
+++ b/build.ps1
@@ -4,8 +4,6 @@
 #Requires -Version 7
 
 param(
-    [Parameter(Mandatory = $false)][string] $Configuration = "Release",
-    [Parameter(Mandatory = $false)][string] $OutputPath = "",
     [Parameter(Mandatory = $false)][switch] $SkipTests
 )
 
@@ -27,10 +25,6 @@ $testProjects = @(
 )
 
 $dotnetVersion = (Get-Content $sdkFile | Out-String | ConvertFrom-Json).sdk.version
-
-if ($OutputPath -eq "") {
-    $OutputPath = Join-Path "$(Convert-Path "$PSScriptRoot")" "artifacts"
-}
 
 $installDotNetSdk = $false;
 
@@ -89,7 +83,7 @@ if ($installDotNetSdk -eq $true) {
 function DotNetPack {
     param([string]$Project)
 
-    & $dotnet pack $Project --output (Join-Path $OutputPath "packages") --configuration $Configuration --include-symbols --include-source
+    & $dotnet pack $Project --include-symbols --include-source
 
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet pack failed with exit code $LASTEXITCODE"
@@ -106,7 +100,7 @@ function DotNetTest {
         $additionalArgs += "GitHubActions;report-warnings=false"
     }
 
-    & $dotnet test $Project --output $OutputPath --configuration $Configuration $additionalArgs
+    & $dotnet test $Project --configuration "Release" $additionalArgs
 
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet test failed with exit code $LASTEXITCODE"


### PR DESCRIPTION
- Attest the binaries from the build artifacts.
- Use artifacts output.
- Ignore any `binlog` files.
