### PR TITLE
Add package publish automation

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-validate": {
+      "version": "0.0.1-preview.304",
+      "commands": [
+        "dotnet-validate"
+      ]
+    }
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,9 +94,6 @@ jobs:
       run: |
         $dotnetValidateVersion = (Get-Content "./.config/dotnet-tools.json" | Out-String | ConvertFrom-Json).tools.'dotnet-validate'.version
         "dotnet-validate-version=${dotnetValidateVersion}" >> $env:GITHUB_OUTPUT
-        # TODO Remover after testing
-        Write-Output "package-names=${{ steps.build.outputs.package-names }}"
-        Write-Output "package-version=${{ steps.build.outputs.package-version }}"
 
   validate-packages:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ jobs:
 
     outputs:
       dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
+      dotnet-validate-version: ${{ steps.get-dotnet-validate-version.outputs.dotnet-validate-version }}
+      package-names: ${{ steps.build.outputs.package-names }}
+      package-version: ${{ steps.build.outputs.package-version }}
 
     permissions:
       attestations: write
@@ -54,6 +57,7 @@ jobs:
       id: setup-dotnet
 
     - name: Build, Test and Package
+      id: build
       shell: pwsh
       run: ./build.ps1
 
@@ -84,6 +88,16 @@ jobs:
         path: ./artifacts/package/release
         if-no-files-found: error
 
+    - name: Get dotnet-validate version
+      id: get-dotnet-validate-version
+      shell: pwsh
+      run: |
+        $dotnetValidateVersion = (Get-Content "./.config/dotnet-tools.json" | Out-String | ConvertFrom-Json).tools.'dotnet-validate'.version
+        "dotnet-validate-version=${dotnetValidateVersion}" >> $env:GITHUB_OUTPUT
+        # TODO Remover after testing
+        Write-Output "package-names=${{ steps.build.outputs.package-names }}"
+        Write-Output "package-version=${{ steps.build.outputs.package-version }}"
+
   validate-packages:
     needs: build
     runs-on: ubuntu-latest
@@ -101,8 +115,10 @@ jobs:
 
     - name: Validate NuGet packages
       shell: pwsh
+      env:
+        DOTNET_VALIDATE_VERSION: ${{ needs.build.outputs.dotnet-validate-version }}
       run: |
-        dotnet tool install --global dotnet-validate --version 0.0.1-preview.304
+        dotnet tool install --global dotnet-validate --version ${env:DOTNET_VALIDATE_VERSION}
         $packages = Get-ChildItem -Filter "*.nupkg" | ForEach-Object { $_.FullName }
         $invalidPackages = 0
         foreach ($package in $packages) {
@@ -173,3 +189,16 @@ jobs:
         API_KEY: ${{ secrets.NUGET_TOKEN }}
         SOURCE: https://api.nuget.org/v3/index.json
       run: dotnet nuget push "*.nupkg" --api-key "${API_KEY}" --skip-duplicate --source "${SOURCE}"
+
+    - name: Publish nuget_packages_published
+      uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+      with:
+        event-type: nuget_packages_published
+        repository: ${{ github.repository_owner }}/github-automation
+        token: ${{ secrets.COSTELLOBOT_TOKEN }}
+        client-payload: |-
+          {
+            "repository": "${{ github.repository }}",
+            "packages": "${{ needs.build.outputs.package-names }}",
+            "version": "${{ needs.build.outputs.package-version }}"
+          }

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,19 @@
+<Project>
+  <Target Name="SetNuGetPackageOutputs" AfterTargets="Pack" Condition=" '$(GITHUB_OUTPUT)' != '' ">
+    <PropertyGroup>
+      <_PackageNamesPath>$(ArtifactsPath)\package-names.txt</_PackageNamesPath>
+    </PropertyGroup>
+    <ReadLinesFromFile File="$(_PackageNamesPath)">
+      <Output TaskParameter="Lines" ItemName="_PackageNames" />
+    </ReadLinesFromFile>
+    <ItemGroup>
+      <_PackageNames Include="$(PackageId)" />
+    </ItemGroup>
+    <RemoveDuplicates Inputs="@(_PackageNames)">
+      <Output TaskParameter="Filtered" ItemName="_UniquePackageNames" />
+    </RemoveDuplicates>
+    <WriteLinesToFile File="$(_PackageNamesPath)" Lines="@(_UniquePackageNames)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="$(GITHUB_OUTPUT)" Lines="package-names=@(_UniquePackageNames->'%(Identity)', ',')" />
+    <WriteLinesToFile File="$(GITHUB_OUTPUT)" Lines="package-version=$(Version)" />
+  </Target>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -12,8 +12,11 @@
     <RemoveDuplicates Inputs="@(_PackageNames)">
       <Output TaskParameter="Filtered" ItemName="_UniquePackageNames" />
     </RemoveDuplicates>
+    <PropertyGroup>
+      <_UniquePackageNames>@(_UniquePackageNames->'%(Identity)', ',')</_UniquePackageNames>
+    </PropertyGroup>
     <WriteLinesToFile File="$(_PackageNamesPath)" Lines="@(_UniquePackageNames)" Overwrite="true" WriteOnlyWhenDifferent="true" />
-    <WriteLinesToFile File="$(GITHUB_OUTPUT)" Lines="package-names=@(_UniquePackageNames->'%(Identity)', ',')" />
+    <WriteLinesToFile File="$(GITHUB_OUTPUT)" Lines="package-names=$(_UniquePackageNames)" />
     <WriteLinesToFile File="$(GITHUB_OUTPUT)" Lines="package-version=$(Version)" />
   </Target>
 </Project>

--- a/PseudoLocalizer.sln
+++ b/PseudoLocalizer.sln
@@ -17,6 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.vsconfig = .vsconfig
 		build.ps1 = build.ps1
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json
 		LICENSE = LICENSE

--- a/build.ps1
+++ b/build.ps1
@@ -112,7 +112,9 @@ ForEach ($packageProject in $packageProjects) {
     DotNetPack $packageProject
 }
 
-Write-Host "Running tests..." -ForegroundColor Green
-ForEach ($testProject in $testProjects) {
-    DotNetTest $testProject
+if (-Not $SkipTests) {
+    Write-Host "Running tests..." -ForegroundColor Green
+    ForEach ($testProject in $testProjects) {
+        DotNetTest $testProject
+    }
 }


### PR DESCRIPTION
- Extend the build workflow to output the NuGet package name and version and then dispatch a `nuget_packages_published` event when the NuGet package is published to NuGet.org.
- Pin the version of dotnet-validate used.
- Fix tests not be skipped with `-SkipTests`.
