### PR TITLE
Add SDK hint paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-.dotnetcli
+.dotnet
 .idea
 .vs
 artifacts

--- a/build.ps1
+++ b/build.ps1
@@ -15,14 +15,9 @@ $solutionPath = $PSScriptRoot
 $sdkFile = Join-Path $solutionPath "global.json"
 
 $packageProjects = @(
-	(Join-Path $solutionPath "PseudoLocalizer.Core" "PseudoLocalizer.Core.csproj"),
-	(Join-Path $solutionPath "PseudoLocalizer.Humanizer" "PseudoLocalizer.Humanizer.csproj"),
-	(Join-Path $solutionPath "PseudoLocalize" "PseudoLocalize.csproj")
-)
-
-$testProjects = @(
-    (Join-Path $solutionPath "PseudoLocalizer.Core.Tests" "PseudoLocalizer.Core.Tests.csproj"),
-    (Join-Path $solutionPath "PseudoLocalize.Tests" "PseudoLocalize.Tests.csproj")
+    (Join-Path $solutionPath "PseudoLocalizer.Core" "PseudoLocalizer.Core.csproj"),
+    (Join-Path $solutionPath "PseudoLocalizer.Humanizer" "PseudoLocalizer.Humanizer.csproj"),
+    (Join-Path $solutionPath "PseudoLocalize" "PseudoLocalize.csproj")
 )
 
 $dotnetVersion = (Get-Content $sdkFile | Out-String | ConvertFrom-Json).sdk.version
@@ -49,7 +44,7 @@ else {
 
 if ($installDotNetSdk) {
 
-    ${env:DOTNET_INSTALL_DIR} = Join-Path $solutionPath ".dotnetcli"
+    ${env:DOTNET_INSTALL_DIR} = Join-Path $solutionPath ".dotnet"
     $sdkPath = Join-Path ${env:DOTNET_INSTALL_DIR} "sdk" $dotnetVersion
 
     if (!(Test-Path $sdkPath)) {
@@ -91,7 +86,7 @@ function DotNetPack {
 }
 
 function DotNetTest {
-    param([string]$Project)
+    param()
 
     $additionalArgs = @()
 
@@ -100,7 +95,7 @@ function DotNetTest {
         $additionalArgs += "GitHubActions;report-warnings=false"
     }
 
-    & $dotnet test $Project --configuration "Release" $additionalArgs
+    & $dotnet test --configuration "Release" $additionalArgs
 
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet test failed with exit code $LASTEXITCODE"
@@ -114,7 +109,5 @@ ForEach ($packageProject in $packageProjects) {
 
 if (-Not $SkipTests) {
     Write-Information "Running tests..."
-    ForEach ($testProject in $testProjects) {
-        DotNetTest $testProject
-    }
+    DotNetTest
 }

--- a/global.json
+++ b/global.json
@@ -2,6 +2,8 @@
   "sdk": {
     "version": "9.0.202",
     "allowPrerelease": false,
-    "rollForward": "latestMajor"
+    "rollForward": "latestMajor",
+    "paths": [ ".dotnet", "$host$" ],
+    "errorMessage": "The required version of the .NET SDK could not be found. Please run ./build.ps1 to bootstrap the .NET SDK."
   }
 }


### PR DESCRIPTION
- Add new .NET 10 properties for locating the .NET SDK.
- Move from `.dotnetcli` to `.dotnet`.
- Run tests in parallel.