### PR TITLE
Bump System.Net.Http

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
     <AnalysisMode>latest-recommended</AnalysisMode>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)PseudoLocalizer.snk</AssemblyOriginatorKeyFile>
     <Authors>anderskaplan;martin_costello</Authors>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <Copyright>Pseudolocalizer Contributors (c) 2012-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <Nullable>disable</Nullable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,5 +9,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Update System.Net.Http to 4.3.4 to resolve vulnerability alerts for transitive dependencies for GHSA-7jgj-8wvc-jh57.
