### PR TITLE
Migrate to actions/attest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         upload-release-assets: false
 
     - name: Attest artifacts
-      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
       if: |
         runner.os == 'Windows' &&
         github.repository_owner == 'martincostello' &&


### PR DESCRIPTION
Migrate from now-deprecated attestation action to `actions/attest`.
