### PR TITLE
Update ignored dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,3 @@ updates:
   schedule:
     interval: yearly
     timezone: Europe/London
-  ignore:
-  - dependency-name: Humanizer


### PR DESCRIPTION
Humanizer doesn't need to be ignored anymore.
