### PR TITLE
Update to .NET 11

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.yml
@@ -59,8 +59,8 @@ body:
     label: .NET Version
     description: |
       Run `dotnet --version` to get the .NET SDK version you're using.
-      Alternatively, which target framework(s) (e.g. `net8.0`) does the project you're using the package with target?
-    placeholder: 9.0.100
+      Alternatively, which target framework(s) (e.g. `net11.0`) does the project you're using the package with target?
+    placeholder: 11.0.100
   validations:
     required: false
 - type: textarea

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,7 @@ jobs:
       uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         dotnet-version: |
-          8.0.x
-          9.0.x
+          10.0.x
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0

--- a/.vsconfig
+++ b/.vsconfig
@@ -3,7 +3,7 @@
   "components": [
     "Microsoft.VisualStudio.Component.CoreEditor",
     "Microsoft.VisualStudio.Workload.CoreEditor",
-    "Microsoft.NetCore.Component.Runtime.8.0",
+    "Microsoft.NetCore.Component.Runtime.11.0",
     "Microsoft.NetCore.Component.SDK",
     "Microsoft.VisualStudio.Component.Roslyn.Compiler",
     "Microsoft.VisualStudio.Component.Roslyn.LanguageServices"

--- a/PseudoLocalize.Tests/PseudoLocalize.Tests.csproj
+++ b/PseudoLocalize.Tests/PseudoLocalize.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>PseudoLocalizer</RootNamespace>
-    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net11.0;net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" />

--- a/PseudoLocalize/PseudoLocalize.csproj
+++ b/PseudoLocalize/PseudoLocalize.csproj
@@ -7,7 +7,7 @@
     <PackAsTool>true</PackAsTool>
     <PackageId>PseudoLocalize</PackageId>
     <RuntimeIdentifier>any</RuntimeIdentifier>
-    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net11.0;net10.0</TargetFrameworks>
     <Title>PseudoLocalize</Title>
     <ToolCommandName>pseudo-localize</ToolCommandName>
     <ToolType>agnostic</ToolType>

--- a/PseudoLocalizer.Core.Tests/PseudoLocalizer.Core.Tests.csproj
+++ b/PseudoLocalizer.Core.Tests/PseudoLocalizer.Core.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>PseudoLocalizer.Core.Tests</RootNamespace>
-    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net11.0;net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.301",
+    "version": "11.0.100-preview.5.26302.115",
     "allowPrerelease": false,
     "paths": [ ".dotnet", "$host$" ],
     "errorMessage": "The required version of the .NET SDK could not be found. Please run ./build.ps1 to bootstrap the .NET SDK."


### PR DESCRIPTION
- Update to build with the .NET 11 SDK.
- Drop testing with .NET 8 and 9.
